### PR TITLE
Makefile.env のパスを athrill プロジェクトの配置場所に依存しないように修正。

### DIFF
--- a/test/env.sh
+++ b/test/env.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-export ATHRILL_HOME=${HOME}/build/tmori/athrill
+export ATHRILL_HOME=${0%/*}/../..
 export PATH=${PATH}:${ATHRILL_HOME}/bin/linux
-export CONFIG_MEMORY=${HOME}/build/tmori/athrill/test/config/memory.txt
-export CONFIG_DEBUG=${HOME}/build/tmori/athrill/test/config/device_config.txt
-export TEST_LOG=${HOME}/build/tmori/athrill/test/scripts/log
+export CONFIG_MEMORY=${ATHRILL_HOME}/test/config/memory.txt
+export CONFIG_DEBUG=${ATHRILL_HOME}/test/config/device_config.txt
+export TEST_LOG=${ATHRILL_HOME}/test/scripts/log
 
 CMD_NAME=
 function util_set_cmdname() {


### PR DESCRIPTION
現在の `ATHRILL_HOME` は `${HOME}/build/tmori/athrill` となっており、 `git clone` する場所が制限されてしまう。
それを回避するように修正しました。