### PR TITLE
fix ATHRILL_HOME in `test/env.sh`.

### DIFF
--- a/test/env.sh
+++ b/test/env.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-export ATHRILL_HOME=${HOME}/build/tmori/athrill
+export ATHRILL_HOME=$(cd $(dirname $BASH_SOURCE);cd ..; pwd)
 export PATH=${PATH}:${ATHRILL_HOME}/bin/linux
-export CONFIG_MEMORY=${HOME}/build/tmori/athrill/test/config/memory.txt
-export CONFIG_DEBUG=${HOME}/build/tmori/athrill/test/config/device_config.txt
-export TEST_LOG=${HOME}/build/tmori/athrill/test/scripts/log
+export CONFIG_MEMORY=${ATHRILL_HOME}/test/config/memory.txt
+export CONFIG_DEBUG=${ATHRILL_HOME}/test/config/device_config.txt
+export TEST_LOG=${ATHRILL_HOME}/test/scripts/log
 
 CMD_NAME=
 function util_set_cmdname() {


### PR DESCRIPTION
`ATHRILL_HOME` が athrill プロジェクトの場所に依存している(`${HOME}/build/tmori/athrill`)。

これでは開発者が自分の好きな場所に clone できないため、どこに clone してもテスト実行可能なように修正しました。